### PR TITLE
Added Alpha connection to blender BDSF

### DIFF
--- a/io_scene_vintagestory_json/import_vintagestory_json.py
+++ b/io_scene_vintagestory_json/import_vintagestory_json.py
@@ -110,6 +110,7 @@ def create_textured_principled_bsdf(mat_name, tex_path):
         
             tex_input.image = img
             node_tree.links.new(tex_input.outputs[0], bsdf.inputs["Base Color"])
+            node_tree.links.new(tex_input.outputs[1], bsdf.inputs["Alpha"]) #  We also want the alpha to be bound to not confuse the end user.
         
         # disable shininess
         if "Specular" in bsdf.inputs:


### PR DESCRIPTION
When vintage story model is imported, make sure to connect the alpha maps to avoid confusion for anyone pickup blender and learning blender at the same time as a tool