### PR TITLE
On Import Create collections

### DIFF
--- a/io_scene_vintagestory_json/import_vintagestory_json.py
+++ b/io_scene_vintagestory_json/import_vintagestory_json.py
@@ -837,6 +837,28 @@ def load(context,
     for obj in all_objects:
         obj.select_set(True)
     
+    # =============================================
+    # Collection
+    # =============================================
+
+
+    # Use the name of the filee to create a new collection 
+    # (as collections can be the main method to be used to separate model files in blender)
+    # and Organize / hide parts that we may not want to get updated, as some attachments
+    # may not have a common "root"'
+    name = filepath_parts[-1].replace(".json", "")
+    if name not in bpy.data.collections:
+        bpy.data.collections.new(name)
+        bpy.context.scene.collection.children.link(bpy.data.collections[name])
+
+    main_collection = bpy.data.collections[name]
+    for obj in all_objects:
+        # unlink from all collections (root)
+        for collection in obj.users_collection:
+            collection.objects.unlink(obj)
+        # link to main file based collection
+        main_collection.objects.link(obj)
+
     # print stats
     if debug_stats:
         t_end = time.process_time()


### PR DESCRIPTION
When import shape entities, make collections instead of raw cubes.

This will allow for easier filtering of models, especially if they have been attached to other entities via constraints