### PR TITLE
Fix some cubes appearing with incorrect rotation when imported

### DIFF
--- a/io_scene_vintagestory_json/import_vintagestory_json.py
+++ b/io_scene_vintagestory_json/import_vintagestory_json.py
@@ -195,6 +195,7 @@ def parse_element(
     # create cube
     bpy.ops.mesh.primitive_cube_add(location=location, rotation=rot_euler)
     obj = bpy.context.active_object
+    obj.rotation_mode = 'XZY'
     mesh = obj.data
     mesh_materials = {} # tex_name => material_index
 


### PR DESCRIPTION
Apply rotations in XZY order, matching the order they were applied in pre-conversion axes.

Sample file where this corrects the imported rotation:
[sample.json](https://github.com/user-attachments/files/18575267/sample.json)
